### PR TITLE
updated string from bytes to use NSByteCountFormatter

### DIFF
--- a/HGUtils.m
+++ b/HGUtils.m
@@ -36,7 +36,14 @@ NSString *stringFromFileSize(long long aSize)
     
     // Finder uses SI prefixes for file sizes and disk capacities
     // (since Snow Leopard) so we'll do the same here.
-    // 
+    //
+    
+    if (NSClassFromString(@"NSByteCountFormatter")) {
+     
+        return [NSByteCountFormatter stringFromByteCount:aSize countStyle:NSByteCountFormatterCountStyleFile];
+        
+    }
+    
     CGFloat kilo = 1000.0;
     
     if (size < kilo)


### PR DESCRIPTION
bytes, in the form of `long long`, are current converted to an NSString using a custom util function that assumes kilo = 1000. (As was the standard since macOS 10.6)

However, in macOS 10.8, Apple added the `NSByteCountFormatter` API to `Foundation`, which not only adds this functionality built in, but can also use the appropriate `kilo` value based on the OS it's currently running on. `NSByteCountFormatter` also supports storage increments greater than TB, incase anyone is every thing to trash a files more than 1000 TB in size 😂

I've updated the util file to check for the presence of `NSByteCountFormatter` and use it if possible, and if not to default to the legacy method.