### PR TITLE
Remove support for i386 architecture for newer OSX versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ trash: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling:
 	@echo ======================================
-	$(CC) -O2 -Wall -Wextra -Wpartial-availability -Wno-unguarded-availability -force_cpusubtype_ALL -mmacosx-version-min=10.7 -arch i386 -arch x86_64 -framework AppKit -framework ScriptingBridge -o $@ $(SOURCE_FILES)
+	$(CC) -O2 -Wall -Wextra -Wpartial-availability -Wno-unguarded-availability -force_cpusubtype_ALL -mmacosx-version-min=10.7 -arch x86_64 -framework AppKit -framework ScriptingBridge -o $@ $(SOURCE_FILES)
 
 analyze:
 	@echo


### PR DESCRIPTION
Removing i386 as a target architecture as it's deprecated on newer macOS versions. Allows to compile on XCode v10.2.1

Related to Issue #34 